### PR TITLE
Plug-in installation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -81,9 +81,9 @@ fi
 if [ -f "$BUILD_DIR/.sfdx-plugins" ]; then
   log "Installing sfdx plugins ..."
   plugins_arg="$(echo -n $(cat $BUILD_DIR/.sfdx-plugins))"
-  /app/vendor/sfdx/cli/bin/sfdx plugins:install $plugins_arg
+  $BUILD_DIR/vendor/sfdx/cli/bin/sfdx plugins:install $plugins_arg
   log "sfdx plugins"
-  /app/vendor/sfdx/cli/bin/sfdx plugins
+  $BUILD_DIR/vendor/sfdx/cli/bin/sfdx plugins
 fi
 
 header "DONE! Completed in $(($SECONDS - $START_TIME))s"

--- a/bin/compile
+++ b/bin/compile
@@ -81,6 +81,7 @@ fi
 if [ -f "$BUILD_DIR/.sfdx-plugins" ]; then
   log "Installing sfdx plugins ..."
   plugins_arg="$(echo -n $(cat $BUILD_DIR/.sfdx-plugins))"
+  export HOME="$BUILD_DIR"
   $BUILD_DIR/vendor/sfdx/cli/bin/sfdx plugins:install $plugins_arg
   log "sfdx plugins"
   $BUILD_DIR/vendor/sfdx/cli/bin/sfdx plugins

--- a/bin/compile
+++ b/bin/compile
@@ -87,5 +87,14 @@ if [ -f "$BUILD_DIR/.sfdx-plugins" ]; then
   $BUILD_DIR/vendor/sfdx/cli/bin/sfdx plugins
 fi
 
+if [ -f "$BUILD_DIR/.sf-plugins" ]; then
+  log "Installing sf plugins ..."
+  plugins_arg="$(echo -n $(cat $BUILD_DIR/.sf-plugins))"
+  export HOME="$BUILD_DIR"
+  $BUILD_DIR/vendor/sfdx/cli/bin/sf plugins install $plugins_arg
+  log "sfdx plugins"
+  $BUILD_DIR/vendor/sfdx/cli/bin/sf plugins
+fi
+
 header "DONE! Completed in $(($SECONDS - $START_TIME))s"
 exit 0

--- a/bin/compile
+++ b/bin/compile
@@ -78,5 +78,13 @@ export PATH=\$PATH:/app/vendor/sfdx/cli/bin/" > $BUILD_DIR/.profile.d/path.sh
   log "Generated $BUILD_DIR/.profile.d/path.sh to add CLI path"
 fi
 
+if [ -f "$BUILD_DIR/.sfdx-plugins" ]; then
+  log "Installing sfdx plugins ..."
+  plugins_arg="$(echo -n $(cat $BUILD_DIR/.sfdx-plugins))"
+  /app/vendor/sfdx/cli/bin/sfdx plugins:install $plugins_arg
+  log "sfdx plugins"
+  /app/vendor/sfdx/cli/bin/sfdx plugins
+fi
+
 header "DONE! Completed in $(($SECONDS - $START_TIME))s"
 exit 0

--- a/bin/compile
+++ b/bin/compile
@@ -92,7 +92,7 @@ if [ -f "$BUILD_DIR/.sf-plugins" ]; then
   plugins_arg="$(echo -n $(cat $BUILD_DIR/.sf-plugins))"
   export HOME="$BUILD_DIR"
   $BUILD_DIR/vendor/sfdx/cli/bin/sf plugins install $plugins_arg
-  log "sfdx plugins"
+  log "sf plugins"
   $BUILD_DIR/vendor/sfdx/cli/bin/sf plugins
 fi
 


### PR DESCRIPTION
New support for `.sfdx_plugins` & `.sf_plugins` config files, new-line delimited lists of plugins (npm modules) to install during build phase of the app.